### PR TITLE
Add `.data$id`

### DIFF
--- a/R/network-plot.R
+++ b/R/network-plot.R
@@ -47,18 +47,18 @@ network_plot <- function(df, to = .data$pkgs, show_each_use = FALSE){
     select(id = {{to}}, value = n) %>%
     mutate(color = "#ECEEFC",
            shape = "dot") %>%
-    mutate(title = paste0("<p><b>", id,"</b><br>"))
+    mutate(title = paste0("<p><b>", .data$id,"</b><br>"))
 
   nodes_contents <- df %>%
     count(.data$relative_paths, .data$absolute_paths) %>%
     select(id = .data$relative_paths, value = .data$n, .data$absolute_paths) %>%
     mutate(color = "#4A6FE3",
            shape = "square") %>%
-    mutate(title = paste0("<p><b>", id,"</b><br> ", .data$absolute_paths, "</p>"))
+    mutate(title = paste0("<p><b>", .data$id,"</b><br> ", .data$absolute_paths, "</p>"))
 
   nodes <- bind_rows(nodes_pkgs,
                      nodes_contents) %>%
-    mutate(label = id)
+    mutate(label = .data$id)
 
   edges <- df %>%
     select(from = .data$relative_paths, to = {{to}}) %>%


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

Your package does one of two things:

- It re-exports `dplyr::id()`, which has been defunct for many years and has now been removed from dplyr.

- It references a column named `id`, likely in a `mutate()` or `summarise()`, but does not note this as a global variable with `utils::globalVariables("id")`. In this case, you got lucky that dplyr exported `id()`, meaning that you did not need a global variable for `"id"`. Since we have removed `dplyr::id()`, your package will need this now.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!